### PR TITLE
Add Organiser Communication clause

### DIFF
--- a/ORGANISER_CHARTER.md
+++ b/ORGANISER_CHARTER.md
@@ -1,4 +1,4 @@
-# Charter for the Organizers of Newcastle Cybersecurity Group (NCSG)
+# Charter for the Organisers of Newcastle Cybersecurity Group (NCSG)
 
 ## Mission Statement
 
@@ -10,21 +10,21 @@ stay updated on the latest developments in the field.
 ## Purpose
 
 The purpose of this charter is to outline the responsibilities and
-expectations of the organizers of the NCSG, ensuring their active involvement
+expectations of the organisers of the NCSG, ensuring their active involvement
 in the success and growth of the group.
 
-## Organizer Responsibilities
+## Organiser Responsibilities
 
 1. **Leadership**
 
-   - Organizers are expected to provide leadership and guidance to the group,
+   - Organisers are expected to provide leadership and guidance to the group,
      fostering an environment of collaboration and mutual respect.
    - They should lead by example, demonstrating professionalism and integrity
      in all interactions within the group.
 
 2. **Event Planning and Coordination**
 
-   - Organizers are responsible for planning and coordinating group meetings,
+   - Organisers are responsible for planning and coordinating group meetings,
      workshops, seminars, and other events.
    - They should ensure that events are relevant, informative, and engaging
      for group members, catering to a diverse range of interests and skill
@@ -32,7 +32,7 @@ in the success and growth of the group.
 
 3. **Communication**
 
-   - Organizers must maintain regular communication with group members,
+   - Organisers must maintain regular communication with group members,
      providing updates on upcoming events, relevant news, and opportunities
      within the cybersecurity community.
    - They should be responsive to inquiries and feedback from group members,
@@ -40,7 +40,7 @@ in the success and growth of the group.
 
 4. **Knowledge Sharing**
 
-   - Organizers should actively participate in knowledge sharing within the
+   - Organisers should actively participate in knowledge sharing within the
      group, contributing insights, resources, and expertise to facilitate
      learning and growth among members.
    - They should encourage collaboration and mentorship opportunities,
@@ -49,46 +49,58 @@ in the success and growth of the group.
 
 5. **Professional Development**
 
-   - Organizers are encouraged to pursue ongoing professional development in
+   - Organisers are encouraged to pursue ongoing professional development in
      the field of cybersecurity, staying updated on emerging trends,
      technologies, and best practices.
    - They should leverage their knowledge and expertise to enhance the
      quality and relevance of the group's activities and events.
 
 6. **Presentation Requirement**
-   - Organizers are required to deliver a presentation or workshop at least
+
+   - Organisers are required to deliver a presentation or workshop at least
      once every two years, flexibly scheduled to accommodate their
      availability and expertise.
    - Presentations should cover topics relevant to cybersecurity, catering
      to the interests and skill levels of group members.
-   - Organizers should use presentations as an opportunity to share their
+   - Organisers should use presentations as an opportunity to share their
      knowledge, insights, and experiences with the group, fostering learning
      and discussion amongst members.
 
+7. **Organisation Communication**
+
+   - All communications related to the organisation and coordination of NCSG must
+     include all other organisers as either active participants or recipients of
+     the communication, with the expectation that any information shared with one
+     organiser is promptly shared with all others.
+     This ensures transparency, collaboration, and equal involvement among all
+     organisers in decision-making processes and organisational activities.
+     Any deviation from this communication practice should be communicated and
+     justified to the other organisers in a timely manner.
+
 ## Adherence as an Absolute Requirement
 
-All organizers are required to adhere strictly to the provisions of this
+All organisers are required to adhere strictly to the provisions of this
 charter. Failure to fulfill their responsibilities as outlined may result in
 reconsideration of their role within the NCSG.
 
 ## Accountability
 
-Organizers are accountable to the members of the NCSG, as well as to each
+Organisers are accountable to the members of the NCSG, as well as to each
 other, for upholding the principles outlined in this charter. In the event of
-any concerns or disputes, organizers should work together to resolve issues in
+any concerns or disputes, organisers should work together to resolve issues in
 a fair and transparent manner, prioritizing the best interests of the group
 and its members.
 
 ## Adherence to Charter
 
-All organizers are expected to read, understand, and strictly adhere to the
+All organisers are expected to read, understand, and strictly adhere to the
 provisions of this charter. Any proposed amendments or revisions to the
-charter must be discussed and approved by the group's organizers, with input
+charter must be discussed and approved by the group's organisers, with input
 from group members as appropriate.
 
 ## Conclusion
 
-By committing to the principles outlined in this charter, the organizers of
+By committing to the principles outlined in this charter, the organisers of
 the NCSG demonstrate their dedication to fostering a vibrant and supportive
 community for cybersecurity professionals and enthusiasts. Through
 collaborative efforts and shared expertise, the group will continue to thrive


### PR DESCRIPTION
The clause intends to address possible miscommunication issues within the organiser team.

Also corrected the spelling of organise throughout document (but not license)